### PR TITLE
Update SAE ACP

### DIFF
--- a/ACPs/194-streaming-asynchronous-execution/README.md
+++ b/ACPs/194-streaming-asynchronous-execution/README.md
@@ -122,12 +122,12 @@ ACP-103 introduced the following variables for calculating the gas price:
 
 ACP-176 provided a mechanism to make $T$ dynamic and set:
 
-```math
+$$
 \begin{align}
 R &= 2 \cdot T \\
 K &= 87 \cdot T
 \end{align}
-```
+$$
 
 The _excess_ actual consumption $x \ge 0$ beyond the target $T$ is tracked via numerical integration and used to calculate the gas price as:
 

--- a/ACPs/194-streaming-asynchronous-execution/README.md
+++ b/ACPs/194-streaming-asynchronous-execution/README.md
@@ -309,7 +309,9 @@ Although they would have to have sufficient funds to theoretically pay for all t
 
 Therefore, the gas charged was modified from being equal to the gas usage to the above $g_C := \max\left(g_U, \frac{g_L}{\lambda}\right)$
 
-Gas limits are typically set higher than expected gas used to allow for a buffer should gas estimates be imprecise. So $\lambda$ should not be set to $1$. However, setting $\lambda$ to $\infty$ would allow users to fill the queue without paying fees.
+The gas limit is typically set higher than the predicted gas consumption to allow for a buffer should the prediction be imprecise.
+This precludes setting $\lambda := 1$.
+Conversely, setting $\lambda := \infty$ would allow users to attack the queue with high-limit, low-consumption transactions.
 
 Setting $\lambda ~:= 2$ allows for a 100% buffer on gas-usage estimates without penalising the sender, while still disincentivising falsely high limits.
 

--- a/ACPs/194-streaming-asynchronous-execution/README.md
+++ b/ACPs/194-streaming-asynchronous-execution/README.md
@@ -330,7 +330,7 @@ by maximizing $\Sigma_{\forall i} (g_L - g_U)_i$ to maximize $x_W - x_A$.
 Recall that the increasing excess occurs such that
 
 $$
-x := x + \frac{g}{R} \cdot (R - T)
+x := x + g \cdot \frac{(R - T)}{R}
 $$
 
 Since we limit the size of the queue to $\omega$, we can derive an upper bound on the difference in the changes to worst-case and actual gas excess:

--- a/ACPs/194-streaming-asynchronous-execution/README.md
+++ b/ACPs/194-streaming-asynchronous-execution/README.md
@@ -270,7 +270,7 @@ A reference implementation is still a work-in-progress. This ACP will be updated
 
 To avoid a DoS vulnerability on execution, we require an upper bound on transaction gas cost (i.e. amount $\times$ price) beyond the regular requirements for transaction validity (e.g. nonce, signature, etc.). We therefore introduced "worst-case cost" validity.
 
-We can prove that, for every transaction, assuming the usage of their full gas limit during execution results in the greatest possible:
+We can prove that if every transaction were to use its full gas limit this would result in the greatest possible:
 
 1. Consumption of gas units (by definition of the gas limit); and
 2. Gas excess $x$ (and therefore gas price) at the time of execution.

--- a/ACPs/194-streaming-asynchronous-execution/README.md
+++ b/ACPs/194-streaming-asynchronous-execution/README.md
@@ -210,7 +210,7 @@ Similarly, the time spent executing a block MUST be calculated based on the pare
 For a _proposed_ block that includes timestamp $t_b$, all ancestors whose execution timestamp $t_e$ is $t_e \leq t_b - \tau$ are considered settled.
 Note that $t_e$ is not an integer as it tracks fractional seconds with gas consumption, which is not the case for $t_b$.
 
-The _proposed_ block must include the `stateRoot` produced by the execution of the most recently settled block.
+The _proposed_ block MUST include the `stateRoot` produced by the execution of the most recently settled block.
 
 For any _newly_ settled blocks, the _proposed_ block must include all execution artifacts:
 - `receiptsRoot`

--- a/ACPs/194-streaming-asynchronous-execution/README.md
+++ b/ACPs/194-streaming-asynchronous-execution/README.md
@@ -67,7 +67,7 @@ The validator selection mechanism for block production is unchanged. However, bl
 
 The block builder is expected to include transactions based on the most recently settled state and to apply worst-case bounds on the execution of the ancestor blocks prior to the most recently settled block.
 
-The worst-case bounds enforce minimum balances of sender accounts and the maximum required base fee. The worst-case bounds are described below [in detail](#specification).
+The worst-case bounds enforce minimum balances of sender accounts and the maximum required base fee. The worst-case bounds are described [below](#block-validity-and-building).
 
 Prior to adding a proposed block to consensus, all validators MUST verify that the block builder correctly enforced the worst-case bounds while building the block. This guarantees that the block can be executed successfully if it is accepted.
 

--- a/ACPs/194-streaming-asynchronous-execution/README.md
+++ b/ACPs/194-streaming-asynchronous-execution/README.md
@@ -65,7 +65,7 @@ flowchart LR
 
 The validator selection mechanism for block production is unchanged. However, block builders are no longer expected to execute transactions during block building.
 
-The block builder is expected to include transactions based on the most recently settled state and to apply worst-case bounds on the execution of the ancestor blocks prior to the most recently settled block.
+The block builder is expected to include transactions by building upon the most recently settled state and to apply worst-case bounds on the execution of the ancestor blocks prior to the most recently settled block.
 
 The worst-case bounds enforce minimum balances of sender accounts and the maximum required base fee. The worst-case bounds are described [below](#block-validity-and-building).
 

--- a/ACPs/194-streaming-asynchronous-execution/README.md
+++ b/ACPs/194-streaming-asynchronous-execution/README.md
@@ -207,7 +207,8 @@ Similarly, the time spent executing a block MUST be calculated based on the pare
 
 ### Block settlement
 
-For a _proposed_ block which includes timestamp $t_b$, all ancestors whose execution timestamp $t_e$ is $t_e + \tau \leq t_b$ are considered settled.
+For a _proposed_ block that includes timestamp $t_b$, all ancestors whose execution timestamp $t_e$ is $t_e \leq t_b - \tau$ are considered settled.
+Note that $t_e$ is not an integer as it tracks fractional seconds with gas consumption, which is not the case for $t_b$.
 
 The _proposed_ block must include the `stateRoot` produced by the execution of the most recently settled block.
 

--- a/ACPs/194-streaming-asynchronous-execution/README.md
+++ b/ACPs/194-streaming-asynchronous-execution/README.md
@@ -49,7 +49,7 @@ flowchart LR
     I[Proposed] --> E[Executed] --> A[Accepted/Settled]
 ```
 
-Under SAE, a block is first _proposed_ by a validator. In order for validators to consider the block valid to insert into the consensus process, it is verified that later _execution_ will succeed. The block is then _accepted_ by consensus. The act of _accepting_ a block _enqueues_ the block to be _executed_. After the block is _executed_, a following block will reference the execution results and _settle_ all transactions in now _executed_ block.
+Under SAE, a block is first _proposed_ by a validator. In order for validators to consider the block valid to insert into the consensus process, it is verified that later _execution_ will succeed. The block is then _accepted_ by consensus. The act of _accepting_ a block _enqueues_ the block to be _executed_. After the block is _executed_, a following block will reference the execution results and _settle_ all transactions in the _executed_ block.
 
 ```mermaid
 flowchart LR

--- a/ACPs/194-streaming-asynchronous-execution/README.md
+++ b/ACPs/194-streaming-asynchronous-execution/README.md
@@ -55,7 +55,7 @@ Under SAE, a block is first _proposed_ by a validator. In order for validators t
 flowchart LR
     I[Proposed] --> A[Accepted]
     A -->|variable delay| E[Executed]
-    E -->|$\tau$ seconds| S[Settled]
+    E -->|τ seconds| S[Settled]
     A -. guarantees .-> S
 ```
 

--- a/ACPs/194-streaming-asynchronous-execution/README.md
+++ b/ACPs/194-streaming-asynchronous-execution/README.md
@@ -68,7 +68,7 @@ The validator selection mechanism for block production is unchanged. However, bl
 
 The block builder is expected to include transactions based on the most recently settled state and to apply worst-case bounds on the execution of the ancestor blocks prior to the most recently settled block.
 
-The worst-case bounds enforce minimum balances of sender accounts and the maximum required base fee. The worst-case bounds are described in detail below in the Specification section.
+The worst-case bounds enforce minimum balances of sender accounts and the maximum required base fee. The worst-case bounds are described below [in detail](#specification).
 
 Prior to adding a proposed block to consensus, all validators MUST verify that the block builder correctly enforced the worst-case bounds while building the block. This guarantees that the block can be executed successfully if it is accepted.
 

--- a/ACPs/194-streaming-asynchronous-execution/README.md
+++ b/ACPs/194-streaming-asynchronous-execution/README.md
@@ -138,7 +138,7 @@ $$M \cdot \exp\left(\frac{x}{K}\right)$$
 
 ### Gas charged
 
-We introduce $g_L$, $g_U$, and $g_C$ as the gas _limit_, _used_ and _charged_ per transaction, respectively. We define
+We introduce $g_L$, $g_U$, and $g_C$ as the gas _limit_, _used_, and _charged_ per transaction, respectively. We define
 
 $$
 g_C := \max\left(g_U, \frac{g_L}{\lambda}\right)

--- a/ACPs/194-streaming-asynchronous-execution/README.md
+++ b/ACPs/194-streaming-asynchronous-execution/README.md
@@ -44,6 +44,12 @@ This ACP does not introduce these, but some form of asynchronous execution is re
 
 In standard, synchronous, execution a block is first _proposed_ by a validator. In order for validators to consider the block valid to insert into the consensus process, it is _executed_. After _execution_, the block is _accepted_ by consensus. The act of _accepting_ a block immediately _settles_ all transactions in the block by including the transaction execution results.
 
+```mermaid
+flowchart LR
+    I[Proposed] --> E[Executed]
+    E --> A[Accepted and Settled]
+```
+
 Under SAE, a block is first _proposed_ by a validator. In order for validators to consider the block valid to insert into the consensus process, it is verified that later _execution_ will succeed. The block is then _accepted_ by consensus. The act of _accepting_ a block _enqueues_ the block to be _executed_. After the block is _executed_, a following block will reference the execution results and _settle_ all transactions in now _executed_ block.
 
 ```mermaid

--- a/ACPs/194-streaming-asynchronous-execution/README.md
+++ b/ACPs/194-streaming-asynchronous-execution/README.md
@@ -92,7 +92,7 @@ Time is measured two ways by the block executor:
 > [!NOTE]
 > Execution timestamps are more granular than block header timestamps to allow sub-second block execution times.
 
-As soon as there is a block available to execute on the execution queue, the block executor starts processing the block.
+As soon as there is a block available in the execution queue, the block executor starts processing the block.
 
 If the block executor's current timestamp is prior to the current block's timestamp, the block executor's timestamp is advanced to the block's timestamp.
 

--- a/ACPs/194-streaming-asynchronous-execution/README.md
+++ b/ACPs/194-streaming-asynchronous-execution/README.md
@@ -286,8 +286,8 @@ The excess, and hence gas price, for every later block $x_{i>k}$ is therefore re
 $$
 \downarrow g_k \implies
 \begin{cases}
-    \downarrow \frac{g}{R} \cdot (R - T) \\
-    \downarrow \frac{g}{R}
+    \downarrow \Delta^+x \propto g_k \\
+    \uparrow \Delta^-x \propto R-g_k
 \end{cases}
 \implies \downarrow \Delta x_k
 \implies \downarrow M \cdot \exp\left(\frac{x_{i>k}}{K}\right)

--- a/ACPs/194-streaming-asynchronous-execution/README.md
+++ b/ACPs/194-streaming-asynchronous-execution/README.md
@@ -78,18 +78,24 @@ Once a block is marked as accepted by consensus, the block is enqueued in a FIFO
 
 #### Executing blocks
 
-As soon as there is a block available to execute on the execution queue, the block executor starts executing the block on top of the last executed (not settled) state.
+There is a constantly alive block executor whose job is to execute blocks taken off the FIFO execution queue.
 
-Time is measured in two ways by the block executor.
+In addition to executing the blocks, the block executor is also expected to provide deterministic timestamps for the beginning and end of execution of a block.
+
+Time is accordingly measured in two ways by the block executor.
 
 1. The timestamp included in the block header.
 2. The amount of gas charged during the execution of blocks.
 
+As soon as there is a block available to execute on the execution queue, the block executor starts processing the block.
+
 If the block executor's current timestamp is prior to the current block's timestamp, the block executor's timestamp is advanced to the block's timestamp.
 
-As the block executor executes blocks, it advances its timestamp according to the expected speed of gas processing.
+The block is then executed on top of the last executed (not settled) state.
 
-After a block is finished executing, the block executor attaches a timestamp to the block to identify when it finished execution.
+After executing the block, the block executor advances its timestamp based on the gas usage of the block.
+
+The block's execution time is now timestamped and the block is available to be settled.
 
 #### Settling blocks
 

--- a/ACPs/194-streaming-asynchronous-execution/README.md
+++ b/ACPs/194-streaming-asynchronous-execution/README.md
@@ -84,7 +84,7 @@ There is a constantly alive block executor whose job is to execute blocks taken 
 
 In addition to executing the blocks, the block executor provides deterministic timestamps for the beginning and end of execution of a block.
 
-Time is accordingly measured in two ways by the block executor.
+Time is measured two ways by the block executor:
 
 1. The timestamp included in the block header.
 2. The amount of gas charged during the execution of blocks.

--- a/ACPs/194-streaming-asynchronous-execution/README.md
+++ b/ACPs/194-streaming-asynchronous-execution/README.md
@@ -76,7 +76,7 @@ Prior to adding a proposed block to consensus, all validators MUST verify that t
 
 #### Accepting blocks
 
-Once a block is marked as accepted by consensus, the block is enqueued in a FIFO execution queue.
+Once a block is marked as accepted by consensus, the block is put in a FIFO execution queue.
 
 #### Executing blocks
 

--- a/ACPs/194-streaming-asynchronous-execution/README.md
+++ b/ACPs/194-streaming-asynchronous-execution/README.md
@@ -193,7 +193,7 @@ x &~:= x + \Delta{t} \cdot (R - T) \\
 $$
 
 > [!NOTE]
-> The update rule here assumes that $t_e$ is a timestamp that can track the passage of time both by gas and by wall-clock time. $\frac{g_C}{R}$ MUST NOT be simply rounded. Rather, the gas accumulation should be left as a fraction.
+> The update rule here assumes that $t_e$ is a timestamp that tracks the passage of time both by gas and by wall-clock time. $\frac{g_C}{R}$ MUST NOT be simply rounded. Rather, the gas accumulation MUST be left as a fraction.
 
 $t_e$ is now this block's execution timestamp.
 

--- a/ACPs/194-streaming-asynchronous-execution/README.md
+++ b/ACPs/194-streaming-asynchronous-execution/README.md
@@ -307,7 +307,7 @@ Therefore, the gas charged was modified from being equal to the gas usage to the
 
 Gas limits are typically set higher than expected gas used to allow for a buffer should gas estimates be imprecise. So $\lambda$ should not be set to $1$. However, setting $\lambda$ to $\infty$ would allow users to fill the queue without paying fees.
 
-Setting $\lambda ~:= 2$ allows for a 100% buffer on gas usage estimates without penalising the sender, while still disincentivising falsely high limits.
+Setting $\lambda ~:= 2$ allows for a 100% buffer on gas-usage estimates without penalising the sender, while still disincentivising falsely high limits.
 
 #### Upper bound on queue DoS
 

--- a/ACPs/194-streaming-asynchronous-execution/README.md
+++ b/ACPs/194-streaming-asynchronous-execution/README.md
@@ -336,7 +336,7 @@ $$
 x := x + g \cdot \frac{(R - T)}{R}
 $$
 
-Since we limit the size of the queue to $\omega$, we can derive an upper bound on the difference in the changes to worst-case and actual gas excess:
+Since we limit the size of the queue to $\omega$, we can derive an upper bound on the difference in the changes to worst-case and actual gas excess caused by the transactions in the queue:
 
 $$
 \begin{align}

--- a/ACPs/194-streaming-asynchronous-execution/README.md
+++ b/ACPs/194-streaming-asynchronous-execution/README.md
@@ -212,7 +212,7 @@ Note that $t_e$ is not an integer as it tracks fractional seconds with gas consu
 
 The _proposed_ block MUST include the `stateRoot` produced by the execution of the most recently settled block.
 
-For any _newly_ settled blocks, the _proposed_ block must include all execution artifacts:
+For any _newly_ settled blocks, the _proposed_ block MUST include all execution artifacts:
 - `receiptsRoot`
 - `logsBloom`
 - `gasUsed`

--- a/ACPs/194-streaming-asynchronous-execution/README.md
+++ b/ACPs/194-streaming-asynchronous-execution/README.md
@@ -197,7 +197,7 @@ $t_e$ is now this block's execution timestamp.
 
 ### Handling gas target changes
 
-When a block is produced which modifies $T$, both the consensus thread and the execution thread will update to the modified $T$ after their own processing of the block.
+When a block is produced which modifies $T$, both the consensus thread and the execution thread will update to the modified $T$ after their own handling of the block.
 
 For example, restrictions of the queue size MUST be calculated based on the parent block's $T$.
 

--- a/ACPs/194-streaming-asynchronous-execution/README.md
+++ b/ACPs/194-streaming-asynchronous-execution/README.md
@@ -47,7 +47,7 @@ In standard, synchronous, execution a block is first _proposed_ by a validator. 
 ```mermaid
 flowchart LR
     I[Proposed] --> E[Executed]
-    E --> A[Accepted and Settled]
+    E --> A[Accepted/Settled]
 ```
 
 Under SAE, a block is first _proposed_ by a validator. In order for validators to consider the block valid to insert into the consensus process, it is verified that later _execution_ will succeed. The block is then _accepted_ by consensus. The act of _accepting_ a block _enqueues_ the block to be _executed_. After the block is _executed_, a following block will reference the execution results and _settle_ all transactions in now _executed_ block.

--- a/ACPs/194-streaming-asynchronous-execution/README.md
+++ b/ACPs/194-streaming-asynchronous-execution/README.md
@@ -186,7 +186,7 @@ After executing a block which was charged $g_C$ gas, the executor's timestamp an
 $$
 \begin{align}
 t_e &~:= t_e + \frac{g_C}{R} \\
-x &~:= x + \frac{g_C}{2} \\
+x &~:= x + \frac{g_C}{R} \cdot (R - T) \\
 \end{align}
 $$
 
@@ -278,7 +278,7 @@ The excess, and hence gas price, for every later block $x_{i>k}$ is therefore re
 $$
 \downarrow g_k \implies
 \begin{cases}
-    \downarrow \frac{g}{2} \\
+    \downarrow \frac{g}{R} \cdot (R - T) \\
     \downarrow \frac{g}{R}
 \end{cases}
 \implies \downarrow \Delta x_k
@@ -326,24 +326,26 @@ by maximizing $\Sigma_{\forall i} (g_L - g_U)_i$ to maximize $x_W - x_A$.
 > [!TIP]
 > Although $D$ shadows a variable in ACP-176, that one is very different to anything here so there won't be confusion.
 
-Recall that the proportionality of capacity per second and target gas per second ($R = 2 \cdot T$) results in increasing excess such that
+Recall that the increasing excess occurs such that
 
 $$
-x := x + \frac{g}{2}
+x := x + \frac{g}{R} \cdot (R - T)
 $$
 
 Since we limit the size of the queue to $\omega$, we can derive an upper bound on the difference in the changes to worst-case and actual gas excess:
 
 $$
 \begin{align}
-\Delta x_A &\ge \frac{\omega}{2 \cdot \lambda} \\
-\Delta x_W &= \frac{\omega}{2} \\
-\Delta x_W - \Delta x_A &\le \frac{\omega}{2} - \frac{\omega}{2 \cdot \lambda} \\
-&= (1-\frac{1}{\lambda}) \cdot \frac{\omega}{2} \\
-&= (1-\frac{1}{\lambda}) \cdot \frac{R \cdot \tau \cdot \lambda}{2} \\
-&= (\lambda-1) \cdot \frac{R \cdot \tau \cdot}{2} \\
-&= (\lambda-1) \cdot \frac{2 \cdot T \cdot \tau}{2} \\
-&= (\lambda-1) \cdot T \cdot \tau \\
+\Delta x_A &\ge \frac{\omega}{\lambda} \cdot \frac{(R - T)}{R} \\
+\Delta x_W &= \omega \cdot \frac{(R - T)}{R} \\
+\Delta x_W - \Delta x_A &\le \omega \cdot \frac{(R - T)}{R} - \frac{\omega}{\lambda} \cdot \frac{(R - T)}{R} \\
+&= \omega \cdot \frac{(R - T)}{R} \cdot \left(1-\frac{1}{\lambda}\right) \\
+&= \omega \cdot \frac{(2 \cdot T - T)}{2 \cdot T} \cdot \left(1-\frac{1}{\lambda}\right) \\
+&= \frac{\omega}{2} \cdot \left(1-\frac{1}{\lambda}\right) \\
+&= \frac{R \cdot \tau \cdot \lambda}{2} \cdot \left(1-\frac{1}{\lambda}\right) \\
+&= \frac{R \cdot \tau}{2} \cdot (\lambda-1) \\
+&= \frac{2 \cdot T \cdot \tau}{2} \cdot (\lambda-1) \\
+&= T \cdot \tau \cdot (\lambda-1) \\
 \end{align}
 $$
 
@@ -361,9 +363,9 @@ When the queue is empty (i.e. the execution stream has caught up with accepted t
 
 $$
 \begin{align}
-D &\le \exp \left( \frac{(\lambda-1) \cdot T \cdot \tau}{K} \right)\\
-&= \exp \left( \frac{(\lambda-1) \cdot T \cdot \tau}{87 \cdot T} \right)\\
-&= \exp \left( \frac{(\lambda-1) \cdot \tau}{87} \right)\\
+D &\le \exp \left( \frac{T \cdot \tau \cdot (\lambda-1)}{K} \right)\\
+&= \exp \left( \frac{T \cdot \tau \cdot (\lambda-1)}{87 \cdot T} \right)\\
+&= \exp \left( \frac{\tau \cdot (\lambda-1)}{87} \right)\\
 \end{align}
 $$
 
@@ -371,7 +373,7 @@ Therefore, for the values suggested by this ACP:
 
 $$
 \begin{align}
-D &\le \exp \left( \frac{(2-1) \cdot 5}{87} \right)\\
+D &\le \exp \left( \frac{5 \cdot (2 - 1)}{87} \right)\\
 &= \exp \left( \frac{5}{87} \right)\\
 &\simeq 1.06\\
 \end{align}

--- a/ACPs/194-streaming-asynchronous-execution/README.md
+++ b/ACPs/194-streaming-asynchronous-execution/README.md
@@ -82,7 +82,7 @@ Once a block is marked as accepted by consensus, the block is put in a FIFO exec
 
 Each client runs a block executor in parallel, which constantly executes the blocks from the FIFO queue.
 
-In addition to executing the blocks, the block executor provides deterministic timestamps for the beginning and end of execution of a block.
+In addition to executing the blocks, the executor provides deterministic timestamps for the beginning and end of each block's execution.
 
 Time is measured two ways by the block executor:
 

--- a/ACPs/194-streaming-asynchronous-execution/README.md
+++ b/ACPs/194-streaming-asynchronous-execution/README.md
@@ -46,8 +46,7 @@ In standard, synchronous, execution a block is first _proposed_ by a validator. 
 
 ```mermaid
 flowchart LR
-    I[Proposed] --> E[Executed]
-    E --> A[Accepted/Settled]
+    I[Proposed] --> E[Executed] --> A[Accepted/Settled]
 ```
 
 Under SAE, a block is first _proposed_ by a validator. In order for validators to consider the block valid to insert into the consensus process, it is verified that later _execution_ will succeed. The block is then _accepted_ by consensus. The act of _accepting_ a block _enqueues_ the block to be _executed_. After the block is _executed_, a following block will reference the execution results and _settle_ all transactions in now _executed_ block.

--- a/ACPs/194-streaming-asynchronous-execution/README.md
+++ b/ACPs/194-streaming-asynchronous-execution/README.md
@@ -105,6 +105,34 @@ The additional delay amortises any spurious slowdowns the block executor may hav
 
 ## Specification
 
+### Background
+
+ACP-103 introduced the following variables for calculating the gas price:
+
+<div align="center">
+
+| | |
+|---|---|
+| $T$ | the target gas consumed per second |
+| $M$ | minimum gas price |
+| $K$ | gas price update constant |
+| $R$ | gas capacity added per second |
+
+</div>
+
+ACP-176 provided a mechanism to make $T$ dynamic and set:
+
+```math
+\begin{align}
+R &= 2 \cdot T \\
+K &= 87 \cdot T
+\end{align}
+```
+
+The _excess_ actual consumption $x \ge 0$ beyond the target $T$ is tracked via numerical integration and used to calculate the gas price as:
+
+$$M \cdot \exp\left(\frac{x}{K}\right)$$
+
 ### Execution queue
 
 Standard, synchronous execution performs block execution prior to consensus sequencing. Instead, let there be a FIFO queue of accepted blocks.
@@ -167,24 +195,6 @@ flowchart LR
 > However, this is not a concern for EOA-to-EOA transfers of value so such transactions are guaranteed in totality.
 
 ### Updating gas price
-
-ACP-103 introduced the following variables for calculating the gas price:
-
-<div align="center">
-
-| | |
-|---|---|
-| $T$ | the target gas consumed per second |
-| $M$ | minimum gas price |
-| $K$ | gas price update constant |
-| $R$ | gas capacity added per second |
-
-</div>
-
-ACP-176 set $R = 2T$ and provided a mechanism to make $T$ dynamic.
-The _excess_ actual consumption $x \ge 0$ beyond the target $T$ is tracked via numerical integration and used to calculate the gas price as:
-
-$$M \cdot \exp\left(\frac{x}{K}\right)$$
 
 While ACPs 103 and 176 compute this price at the resolution of a single block, we can instead integrate at the resolution of a single transaction with equivalent pricing dynamics.
 Exploiting the proportionality of $R = pT$ with $p \ge 1$, for a transaction consuming $g$ gas, the excess is increased:

--- a/ACPs/194-streaming-asynchronous-execution/README.md
+++ b/ACPs/194-streaming-asynchronous-execution/README.md
@@ -94,7 +94,8 @@ Time is measured two ways by the block executor:
 
 As soon as there is a block available in the execution queue, the block executor starts processing the block.
 
-If the block executor's current timestamp is prior to the current block's timestamp, the block executor's timestamp is advanced to the block's timestamp.
+If the executor's current timestamp is prior to the current block's timestamp, the executor's timestamp is advanced to match the block's.
+Advancing the timestamp in this scenario results in unused gas capacity, reducing the gas _excess_ from which the price is determined.
 
 The block is then executed on top of the last executed (not settled) state.
 

--- a/ACPs/194-streaming-asynchronous-execution/README.md
+++ b/ACPs/194-streaming-asynchronous-execution/README.md
@@ -397,7 +397,7 @@ In particular, the API method `eth_getBlockReceipts` MUST return the receipts co
 #### Named blocks
 
 The Ethereum Mainnet APIs allow for retrieving blocks by named parameters that the API server resolves based on their consensus mechanism.
-Other than the _earliest_ (genesis) named block, which MUST be interpreted in the same manner, all other named blocks are mapped to SAE in terms of the execution status of blocks and MUST be interpreted as follows:
+Other than the _earliest_ (genesis) named block, which MUST be interpreted in the same manner, all other named blocks are mapped to SAE in terms of the _execution_ status of blocks and MUST be interpreted as follows:
 
  * _pending_: the most recently _accepted_ block;
  * _latest_: the block that was most recently _executed_;

--- a/ACPs/194-streaming-asynchronous-execution/README.md
+++ b/ACPs/194-streaming-asynchronous-execution/README.md
@@ -105,7 +105,9 @@ The block's execution time is now timestamped and the block is available to be s
 
 #### Settling blocks
 
-Previously executed blocks are settled by the acceptance of a new block whose timestamp is greater than or equal to the execution time of a prior block plus a constant additional delay.
+Already-executed blocks are settled once a following block that includes the results of the executed block is accepted.
+The results are included by setting the state root to that of the last executed block and the receipt root to that of a MPT of all receipts since last settlement, possibly from more than one block.
+The following block's timestamp is used to determine which blocks to settle—blocks are settled if said timestamp is greater than or equal to the execution time of the executed block plus a constant delay.
 
 The additional delay amortises any sporadic slowdowns the block executor may have encountered.
 

--- a/ACPs/194-streaming-asynchronous-execution/README.md
+++ b/ACPs/194-streaming-asynchronous-execution/README.md
@@ -155,7 +155,7 @@ In all previous instances where execution referenced gas used, from now on, we w
 
 ### Queue size
 
-The constant time delay between execution and settlement is defined as $\tau$ seconds.
+The constant time delay between block execution and settlement is defined as $\tau$ seconds.
 
 The maximum allowed size of the execution queue is defined as:
 

--- a/ACPs/194-streaming-asynchronous-execution/README.md
+++ b/ACPs/194-streaming-asynchronous-execution/README.md
@@ -180,7 +180,7 @@ x &~:= \max\left(x - T \cdot \Delta{t}, 0\right) \\
 \end{align}
 $$
 
-The block is then executed with the gas price calculated by the current value of $x$.
+The block is then executed with the gas price calculated from the current value of $x$.
 
 After executing a block which was charged $g_C$ gas, the executor's timestamp and excess is updated:
 

--- a/ACPs/194-streaming-asynchronous-execution/README.md
+++ b/ACPs/194-streaming-asynchronous-execution/README.md
@@ -147,6 +147,18 @@ where $\lambda$ enforces a lower bound on the gas charged based on the gas limit
 
 In all cases that execution used to refer to gas usage, we will from now on consider gas charged. For example, the gas excess $x$ will be modified by $g_C$ rather than $g_U$.
 
+### Queue size
+
+The constant time delay between execution and settlement is defined as $\tau$ seconds.
+
+The maximum allowed size of the execution queue is defined as:
+
+$$
+\omega ~:= R \cdot \tau \cdot \lambda
+$$
+
+Any block that could cause the total sum of gas limits for transactions in the execution queue to exceed $\omega$ MUST be considered invalid.
+
 ### Execution queue
 
 Standard, synchronous execution performs block execution prior to consensus sequencing. Instead, let there be a FIFO queue of accepted blocks.
@@ -336,7 +348,7 @@ $$
 x := x + \frac{g (p-1)}{p}.
 $$
 
-If we allow the queue to have a bandwidth of $R\lambda^{-1}$ gas/second and limit its length $\tau$ seconds or a back-pressure window of $\omega = \tau R \lambda^{-1}$ gas, we can derive an upper bound on the difference in the changes to worst-case and actual gas excess:
+Since we limit the size of the queue to $\omega$, we can derive an upper bound on the difference in the changes to worst-case and actual gas excess:
 
 $$
 \begin{align}

--- a/ACPs/194-streaming-asynchronous-execution/README.md
+++ b/ACPs/194-streaming-asynchronous-execution/README.md
@@ -427,7 +427,7 @@ As EOA-to-EOA transfers of value are entirely guaranteed upon _acceptance_, bloc
 
 A reliable marker of such transactions is a gas limit of 21,000 as this is an indication from the sender that they do not intend to execute bytecode.
 
-This could delay the ability to issue transactions that depend on these EOA-to-EOA transfers.
+However, this could delay the ability to issue transactions that depend on these EOA-to-EOA transfers.
 
 Block builders are free to make their own decisions around which transactions to include.
 

--- a/ACPs/194-streaming-asynchronous-execution/README.md
+++ b/ACPs/194-streaming-asynchronous-execution/README.md
@@ -199,7 +199,7 @@ $t_e$ is now this block's execution timestamp.
 
 ### Handling gas target changes
 
-When a block is produced which modifies $T$, both the consensus thread and the execution thread will update to the modified $T$ after their own handling of the block.
+When a block is produced that modifies $T$, both the consensus thread and the execution thread will update to the modified $T$ after their own handling of the block.
 
 For example, restrictions of the queue size MUST be calculated based on the parent block's $T$.
 

--- a/ACPs/194-streaming-asynchronous-execution/README.md
+++ b/ACPs/194-streaming-asynchronous-execution/README.md
@@ -49,7 +49,7 @@ flowchart LR
     I[Proposed] --> E[Executed] --> A[Accepted/Settled]
 ```
 
-Under SAE, a block is first _proposed_ by a validator. In order for validators to consider the block valid for consensus, it is verified that _execution_ will later succeed. The block is then _accepted_ by consensus. The act of _accepting_ a block _enqueues_ the block to be _executed_. After the block is _executed_, a following block will reference the execution results and _settle_ all transactions in the _executed_ block.
+Under SAE, a block is considered valid if all of its transactions can be paid for when eventually _executed_, after which the block is _accepted_ by consensus. The act of _acceptance_ enqueues the block to be _executed_ asynchronously. In the future, some as-yet-unknown later block will reference the execution results and _settle_ all transactions from the _executed_ block.
 
 ```mermaid
 flowchart LR

--- a/ACPs/194-streaming-asynchronous-execution/README.md
+++ b/ACPs/194-streaming-asynchronous-execution/README.md
@@ -143,10 +143,10 @@ $$
 g_C := \max\left(g_U, \frac{g_L}{\lambda}\right)
 $$
 
+where $\lambda$ enforces a lower bound on the gas charged based on the gas limit.
+
 > [!NOTE]
 > $\dfrac{g_L}{\lambda}$ is rounded up by actually calculating $\dfrac{g_L + \lambda - 1}{\lambda}$
-
-where $\lambda$ enforces a lower bound on the gas charged based on the gas limit.
 
 In all cases that execution used to refer to gas usage, we will from now on consider gas charged. For example, the gas excess $x$ will be modified by $g_C$ rather than $g_U$.
 

--- a/ACPs/194-streaming-asynchronous-execution/README.md
+++ b/ACPs/194-streaming-asynchronous-execution/README.md
@@ -275,7 +275,8 @@ For a queue of blocks $Q = \\{i\\}_ {i \ge 0}$ the gas excess $x_j$ immediately 
 
 To see this, consider block $0 \le k<j$ consuming gas $g_k$.
 A decrease in $g_k$ reduces the immediate increase of $x$.
-Furthermore, this lowered consumption can only further reduce $x$ at the start of executing the next block. Hence any decrease of $x$ is $\ge$ predicted.
+Furthermore, this lowered consumption might further reduce $x$ at the start of executing the next block if $t^k_e < t^{k+1}_b$ and therefore $\Delta t > 0$.
+Hence any decrease of $x$ is $\ge$ predicted.
 The excess, and hence gas price, for every later block $x_{i>k}$ is therefore reduced:
 
 $$

--- a/ACPs/194-streaming-asynchronous-execution/README.md
+++ b/ACPs/194-streaming-asynchronous-execution/README.md
@@ -71,6 +71,9 @@ The worst-case bounds enforce minimum balances of sender accounts and the maximu
 
 Prior to adding a proposed block to consensus, all validators MUST verify that the block builder correctly enforced the worst-case bounds while building the block. This guarantees that the block can be executed successfully if it is accepted.
 
+> [!NOTE]
+> The worst-case bounds guarantee does not provide assurance about whether or not a transaction will revert nor whether its computation will run out of gas by reaching the specified limit. The verification only ensures the transaction is capable of paying for the accrued fees.
+
 #### Accepting blocks
 
 Once a block is marked as accepted by consensus, the block is enqueued in a FIFO execution queue.

--- a/ACPs/194-streaming-asynchronous-execution/README.md
+++ b/ACPs/194-streaming-asynchronous-execution/README.md
@@ -79,7 +79,7 @@ Once a block is marked as accepted by consensus, the block is enqueued in a FIFO
 
 There is a constantly alive block executor whose job is to execute blocks taken off the FIFO execution queue.
 
-In addition to executing the blocks, the block executor is also expected to provide deterministic timestamps for the beginning and end of execution of a block.
+In addition to executing the blocks, the block executor provides deterministic timestamps for the beginning and end of execution of a block.
 
 Time is accordingly measured in two ways by the block executor.
 

--- a/ACPs/194-streaming-asynchronous-execution/README.md
+++ b/ACPs/194-streaming-asynchronous-execution/README.md
@@ -54,9 +54,9 @@ Under SAE, a block is first _proposed_ by a validator. In order for validators t
 ```mermaid
 flowchart LR
     I[Proposed] --> A[Accepted]
-    A -->| variable delay | E[Executed]
-    E -->| τ seconds | S[Settled]
-    A -. | guarantees | .-> S
+    A -->|variable delay| E[Executed]
+    E -->|τ seconds| S[Settled]
+    A -. guarantees .-> S
 ```
 
 ### Block lifecycle

--- a/ACPs/194-streaming-asynchronous-execution/README.md
+++ b/ACPs/194-streaming-asynchronous-execution/README.md
@@ -225,6 +225,8 @@ The worst-case bound on $x$ can be calculated by following the block executor up
 
 The worst-case bound on account balances can be calculated by charging the worst-case gas cost to the sender of a transaction along with deducting the value of the transaction from the sender's account balance.
 
+The `baseFeePerGas` field must be populated to the gas price based on the worst-case bound on $x$ at the start of block execution.
+
 ### Configuration Parameters
 
 As noted above, SAE depends on the values of $\tau$ and $\lambda$ to be set as parameters and the value of $\omega$ is derived from $T$. 

--- a/ACPs/194-streaming-asynchronous-execution/README.md
+++ b/ACPs/194-streaming-asynchronous-execution/README.md
@@ -80,7 +80,7 @@ Once a block is marked as accepted by consensus, the block is put in a FIFO exec
 
 #### Executing blocks
 
-There is a constantly alive block executor whose job is to execute blocks taken off the FIFO execution queue.
+Each client runs a block executor in parallel, which constantly executes the blocks from the FIFO queue.
 
 In addition to executing the blocks, the block executor provides deterministic timestamps for the beginning and end of execution of a block.
 

--- a/ACPs/194-streaming-asynchronous-execution/README.md
+++ b/ACPs/194-streaming-asynchronous-execution/README.md
@@ -311,7 +311,7 @@ Setting $\lambda ~:= 2$ allows for a 100% buffer on gas-usage estimates without 
 
 #### Upper bound on queue DoS
 
-With $R$ (gas capacity per second) for rate and $g_C$ (gas charged) as already defined.
+Recall $R$ (gas capacity per second) for rate and $g_C$ (gas charged) as already defined.
 
 The actual gas excess $x_A$ has an upper bound of the worst-case excess $x_W$, both of which can be used to calculate respective base fees $f_A$ and $f_W$ (the variable element of gas prices) from the existing exponential function:
 

--- a/ACPs/194-streaming-asynchronous-execution/README.md
+++ b/ACPs/194-streaming-asynchronous-execution/README.md
@@ -42,7 +42,7 @@ This ACP does not introduce these, but some form of asynchronous execution is re
 
 ## Description
 
-In standard, synchronous, execution a block is first _proposed_ by a validator. In order for validators to consider the block valid to insert into the consensus process, it is _executed_. After _execution_, the block is _accepted_ by consensus. The act of _accepting_ a block immediately _settles_ all transactions in the block by including the transaction execution results.
+In all execution models, a block is _proposed_ and then verified by validators before being _accepted_. To assess a block's validity in _synchronous_ execution, its transactions are first _executed_ and only then _accepted_ by consensus. This immediately and implicitly _settles_ all of the block's transactions by including their execution results at the time of _acceptance_.
 
 ```mermaid
 flowchart LR

--- a/ACPs/194-streaming-asynchronous-execution/README.md
+++ b/ACPs/194-streaming-asynchronous-execution/README.md
@@ -54,9 +54,9 @@ Under SAE, a block is first _proposed_ by a validator. In order for validators t
 ```mermaid
 flowchart LR
     I[Proposed] --> A[Accepted]
-    A -->|variable delay| E[Executed]
-    E -->|τ seconds| S[Settled]
-    A -. guarantees .-> S
+    A -->| variable delay | E[Executed]
+    E -->| τ seconds | S[Settled]
+    A -. | guarantees | .-> S
 ```
 
 ### Block lifecycle

--- a/ACPs/194-streaming-asynchronous-execution/README.md
+++ b/ACPs/194-streaming-asynchronous-execution/README.md
@@ -162,6 +162,37 @@ $$
 
 Any block that could cause the total sum of gas limits for transactions in the execution queue to exceed $\omega$ MUST be considered invalid.
 
+### Block executor
+
+During the activation of SAE, the block executor's timestamp, $t_e$, is initialised to the timestamp of the last accepted block.
+
+Prior to executing a block which includes timestamp $t_b$, the executor's timestamp and excess is updated:
+
+$$
+\begin{align}
+\Delta{t} &~:= \max\left(t_e, t_b\right) - t_e \\
+t_e &~:= t_e + \Delta{t} \\
+x &~:= \max\left(x - T \cdot \Delta{t}, 0\right) \\
+\end{align}
+$$
+
+The block is then executed with this gas price.
+
+After executing a block which was charged $g_C$ gas, the executor's timestamp and excess is updated:
+
+$$
+\begin{align}
+t_e &~:= t_e + \frac{g_C}{R} \\
+x &~:= x + \frac{g_C}{2} \\
+\end{align}
+$$
+
+### Handling gas target changes
+
+When a block is produced which modifies $T$, both the consensus thread and the execution thread will update to the modified $T$ after their own processing of the block.
+
+For example, restrictions of the queue size MUST be calculated based on the parent block's $T$. Similarly, the time spent executing a block MUST be calculated based on the parent block's $T$.
+
 ### Execution queue
 
 Standard, synchronous execution performs block execution prior to consensus sequencing. Instead, let there be a FIFO queue of accepted blocks.

--- a/ACPs/194-streaming-asynchronous-execution/README.md
+++ b/ACPs/194-streaming-asynchronous-execution/README.md
@@ -219,6 +219,8 @@ For any _newly_ settled blocks, the _proposed_ block MUST include all execution 
 - `logsBloom`
 - `gasUsed`
 
+The receipts root MUST be computed as defined in [EIP-2718](https://eips.ethereum.org/EIPS/eip-2718) except that the tree MUST be built from the concatenation of receipts from all blocks being settled.
+
 > [!NOTE]
 > If the block executor has fallen behind, the node may not be able to determine precisely which ancestors should be considered settled. If this occurs, validators MUST allow the block executor to catch up prior to deciding the block's validity.
 

--- a/ACPs/194-streaming-asynchronous-execution/README.md
+++ b/ACPs/194-streaming-asynchronous-execution/README.md
@@ -143,6 +143,9 @@ $$
 g_C := \max\left(g_U, \frac{g_L}{\lambda}\right)
 $$
 
+> [!NOTE]
+> $\frac{g_L}{\lambda}$ is rounded up by actually calculating $\frac{g_L + \lambda - 1}{\lambda}$
+
 where $\lambda$ enforces a lower bound on the gas charged based on the gas limit.
 
 In all cases that execution used to refer to gas usage, we will from now on consider gas charged. For example, the gas excess $x$ will be modified by $g_C$ rather than $g_U$.

--- a/ACPs/194-streaming-asynchronous-execution/README.md
+++ b/ACPs/194-streaming-asynchronous-execution/README.md
@@ -182,7 +182,7 @@ $$
 
 The block is then executed with the gas price calculated from the current value of $x$.
 
-After executing a block which was charged $g_C$ gas, the executor's timestamp and excess is updated:
+After executing a block that charged $g_C$ gas in total, the executor's timestamp and excess is updated:
 
 $$
 \begin{align}

--- a/ACPs/194-streaming-asynchronous-execution/README.md
+++ b/ACPs/194-streaming-asynchronous-execution/README.md
@@ -185,8 +185,9 @@ After executing a block which was charged $g_C$ gas, the executor's timestamp an
 
 $$
 \begin{align}
-t_e &~:= t_e + \frac{g_C}{R} \\
-x &~:= x + \frac{g_C}{R} \cdot (R - T) \\
+\Delta{t} &~:= \frac{g_C}{R} \\
+t_e &~:= t_e + \Delta{t} \\
+x &~:= x + \Delta{t} \cdot (R - T) \\
 \end{align}
 $$
 

--- a/ACPs/194-streaming-asynchronous-execution/README.md
+++ b/ACPs/194-streaming-asynchronous-execution/README.md
@@ -136,6 +136,18 @@ The _excess_ actual consumption $x \ge 0$ beyond the target $T$ is tracked via n
 
 $$M \cdot \exp\left(\frac{x}{K}\right)$$
 
+### Gas charged
+
+We introduce $g_L$, $g_U$, and $g_C$ as the gas _limit_, _used_ and _charged_ per transaction, respectively. We define
+
+$$
+g_C := \max\left(g_U, \frac{g_L}{\lambda}\right)
+$$
+
+where $\lambda$ enforces a lower bound on the gas charged based on the gas limit.
+
+In all cases that execution used to refer to gas usage, we will from now on consider gas charged. For example, the gas excess $x$ will be modified by $g_C$ rather than $g_U$.
+
 ### Execution queue
 
 Standard, synchronous execution performs block execution prior to consensus sequencing. Instead, let there be a FIFO queue of accepted blocks.
@@ -300,13 +312,7 @@ A lower bound of 50% of the specified limit, for example, would allow for a 100%
 
 #### Upper bound on queue DoS
 
-With $R$ (for rate) as already defined (gas capacity per second), we introduce $g_L$, $g_U$, and $g_C$ as gas _limit_, _used_ and _charged_ per transaction, respectively, and
-
-$$
-g_C := \max(g_U, \lambda \cdot g_L)
-$$
-
-where $\lambda$ enforces a lower bound on the charge.
+With $R$ (gas capacity per second) for rate and $g_C$ (gas charged) as already defined.
 
 The actual gas excess $x_A$ has an upper bound of the worst-case excess $x_W$, both of which can be used to calculate respective base fees $f_A$ and $f_W$ (the variable element of gas prices) from the existing exponential function:
 

--- a/ACPs/194-streaming-asynchronous-execution/README.md
+++ b/ACPs/194-streaming-asynchronous-execution/README.md
@@ -144,7 +144,7 @@ g_C := \max\left(g_U, \frac{g_L}{\lambda}\right)
 $$
 
 > [!NOTE]
-> $\frac{g_L}{\lambda}$ is rounded up by actually calculating $\frac{g_L + \lambda - 1}{\lambda}$
+> $\dfrac{g_L}{\lambda}$ is rounded up by actually calculating $\dfrac{g_L + \lambda - 1}{\lambda}$
 
 where $\lambda$ enforces a lower bound on the gas charged based on the gas limit.
 

--- a/ACPs/194-streaming-asynchronous-execution/README.md
+++ b/ACPs/194-streaming-asynchronous-execution/README.md
@@ -99,7 +99,7 @@ Advancing the timestamp in this scenario results in unused gas capacity, reducin
 
 The block is then executed on top of the last executed (not settled) state.
 
-After executing the block, the block executor advances its timestamp based on the gas usage of the block.
+After executing the block, the executor advances its timestamp based on the gas usage of the block, also increasing the gas _excess_ for the pricing algorithm.
 
 The block's execution time is now timestamped and the block is available to be settled.
 

--- a/ACPs/194-streaming-asynchronous-execution/README.md
+++ b/ACPs/194-streaming-asynchronous-execution/README.md
@@ -55,7 +55,7 @@ Under SAE, a block is first _proposed_ by a validator. In order for validators t
 flowchart LR
     I[Proposed] --> A[Accepted]
     A -->|variable delay| E[Executed]
-    E -->|d seconds| S[Settled]
+    E -->|$\tau$ seconds| S[Settled]
     A -. guarantees .-> S
 ```
 

--- a/ACPs/194-streaming-asynchronous-execution/README.md
+++ b/ACPs/194-streaming-asynchronous-execution/README.md
@@ -49,7 +49,7 @@ flowchart LR
     I[Proposed] --> E[Executed] --> A[Accepted/Settled]
 ```
 
-Under SAE, a block is first _proposed_ by a validator. In order for validators to consider the block valid to insert into the consensus process, it is verified that later _execution_ will succeed. The block is then _accepted_ by consensus. The act of _accepting_ a block _enqueues_ the block to be _executed_. After the block is _executed_, a following block will reference the execution results and _settle_ all transactions in the _executed_ block.
+Under SAE, a block is first _proposed_ by a validator. In order for validators to consider the block valid for consensus, it is verified that _execution_ will later succeed. The block is then _accepted_ by consensus. The act of _accepting_ a block _enqueues_ the block to be _executed_. After the block is _executed_, a following block will reference the execution results and _settle_ all transactions in the _executed_ block.
 
 ```mermaid
 flowchart LR

--- a/ACPs/194-streaming-asynchronous-execution/README.md
+++ b/ACPs/194-streaming-asynchronous-execution/README.md
@@ -88,7 +88,7 @@ Time is accordingly measured in two ways by the block executor.
 2. The amount of gas charged during the execution of blocks.
 
 > [!NOTE]
-> Execution timestamp are more granular than block header timestamps. This is required to support sub-second block execution times.
+> Execution timestamp are more granular than block header timestamps to allow sub-second block execution times.
 
 As soon as there is a block available to execute on the execution queue, the block executor starts processing the block.
 

--- a/ACPs/194-streaming-asynchronous-execution/README.md
+++ b/ACPs/194-streaming-asynchronous-execution/README.md
@@ -225,6 +225,21 @@ The worst-case bound on $x$ can be calculated by following the block executor up
 
 The worst-case bound on account balances can be calculated by charging the worst-case gas cost to the sender of a transaction along with deducting the value of the transaction from the sender's account balance.
 
+### Configuration Parameters
+
+As noted above, SAE depends on the values of $\tau$ and $\lambda$ to be set as parameters and the value of $\omega$ is derived from $T$. 
+
+Parameters to specify for the C-Chain are:
+
+<div align="center">
+
+| Parameter | Description | C-Chain Configuration|
+| - | - | - |
+| $\tau$ | duration between execution and settlement | $5s$ |
+| $\lambda$ | minimum conversion from gas limit to gas charged | $2$ |
+
+</div>
+
 ## Backwards Compatibility
 
 This ACP modifies the meaning of multiple fields in the block. A comprehensive list of changes will be produced once a reference implementation is available.
@@ -359,6 +374,10 @@ D &\le \exp \left( \frac{(2-1) \cdot 5}{87} \right)\\
 &\simeq 1.06\\
 \end{align}
 $$
+
+In summary, Mallory can require users to increase their gas price by at most ~6%. In practice, the gas price often fluctuates more than 6% on a regular basis. Therefore, this does not appear to be a significant attack vector.
+
+However, any deviation that dislodges the gas price bidding mechanism from a true bidding mechanism is of note.
 
 ## Appendix
 

--- a/ACPs/194-streaming-asynchronous-execution/README.md
+++ b/ACPs/194-streaming-asynchronous-execution/README.md
@@ -106,7 +106,7 @@ The block's execution time is now timestamped and the block is available to be s
 
 Previously executed blocks are settled by the acceptance of a new block whose timestamp is greater than or equal to the execution time of a prior block plus a constant additional delay.
 
-The additional delay amortises any spurious slowdowns the block executor may have encountered.
+The additional delay amortises any sporadic slowdowns the block executor may have encountered.
 
 ## Specification
 

--- a/ACPs/194-streaming-asynchronous-execution/README.md
+++ b/ACPs/194-streaming-asynchronous-execution/README.md
@@ -168,7 +168,7 @@ Any block that could cause the total sum of gas limits for transactions in the e
 
 ### Block executor
 
-During the activation of SAE, the block executor's timestamp, $t_e$, is initialised to the timestamp of the last accepted block.
+During the activation of SAE, the block executor's timestamp $t_e$ is initialised to the timestamp of the last accepted block.
 
 Prior to executing a block with timestamp $t_b$, the executor's timestamp and excess is updated:
 

--- a/ACPs/194-streaming-asynchronous-execution/README.md
+++ b/ACPs/194-streaming-asynchronous-execution/README.md
@@ -151,7 +151,7 @@ where $\lambda$ enforces a lower bound on the gas charged based on the gas limit
 > [!NOTE]
 > $\dfrac{g_L}{\lambda}$ is rounded up by actually calculating $\dfrac{g_L + \lambda - 1}{\lambda}$
 
-In all cases that execution used to refer to gas usage, we will from now on consider gas charged. For example, the gas excess $x$ will be modified by $g_C$ rather than $g_U$.
+In all previous instances where execution referenced gas used, from now on, we will reference gas charged. For example, the gas excess $x$ will be modified by $g_C$ rather than $g_U$.
 
 ### Queue size
 

--- a/ACPs/194-streaming-asynchronous-execution/README.md
+++ b/ACPs/194-streaming-asynchronous-execution/README.md
@@ -90,7 +90,7 @@ Time is accordingly measured in two ways by the block executor.
 2. The amount of gas charged during the execution of blocks.
 
 > [!NOTE]
-> Execution timestamp are more granular than block header timestamps to allow sub-second block execution times.
+> Execution timestamps are more granular than block header timestamps to allow sub-second block execution times.
 
 As soon as there is a block available to execute on the execution queue, the block executor starts processing the block.
 

--- a/ACPs/194-streaming-asynchronous-execution/README.md
+++ b/ACPs/194-streaming-asynchronous-execution/README.md
@@ -196,7 +196,9 @@ $t_e$ is now this block's execution timestamp.
 
 When a block is produced which modifies $T$, both the consensus thread and the execution thread will update to the modified $T$ after their own processing of the block.
 
-For example, restrictions of the queue size MUST be calculated based on the parent block's $T$. Similarly, the time spent executing a block MUST be calculated based on the parent block's $T$.
+For example, restrictions of the queue size MUST be calculated based on the parent block's $T$.
+
+Similarly, the time spent executing a block MUST be calculated based on the parent block's $T$.
 
 ### Block settlement
 
@@ -348,7 +350,7 @@ In particular, the API method `eth_getBlockReceipts` MUST return the receipts co
 #### Named blocks
 
 The Ethereum Mainnet APIs allow for retrieving blocks by named parameters that the API server resolves based on their consensus mechanism.
-Other than the _earliest_ (genesis) named block, which MUST be interpreted in the same manner, all other named blocks are mapped to SAE in terms of the execution status of all block transactions and MUST be interpreted as follows:
+Other than the _earliest_ (genesis) named block, which MUST be interpreted in the same manner, all other named blocks are mapped to SAE in terms of the execution status of blocks and MUST be interpreted as follows:
 
  * _pending_: the most recently _accepted_ block;
  * _latest_: the block that was most recently _executed_;

--- a/ACPs/194-streaming-asynchronous-execution/README.md
+++ b/ACPs/194-streaming-asynchronous-execution/README.md
@@ -190,6 +190,8 @@ x &~:= x + \frac{g_C}{2} \\
 \end{align}
 $$
 
+$t_e$ is now this block's execution timestamp.
+
 ### Handling gas target changes
 
 When a block is produced which modifies $T$, both the consensus thread and the execution thread will update to the modified $T$ after their own processing of the block.

--- a/ACPs/194-streaming-asynchronous-execution/README.md
+++ b/ACPs/194-streaming-asynchronous-execution/README.md
@@ -87,6 +87,9 @@ Time is accordingly measured in two ways by the block executor.
 1. The timestamp included in the block header.
 2. The amount of gas charged during the execution of blocks.
 
+> [!NOTE]
+> Execution timestamp are more granular than block header timestamps. This is required to support sub-second block execution times.
+
 As soon as there is a block available to execute on the execution queue, the block executor starts processing the block.
 
 If the block executor's current timestamp is prior to the current block's timestamp, the block executor's timestamp is advanced to the block's timestamp.

--- a/ACPs/194-streaming-asynchronous-execution/README.md
+++ b/ACPs/194-streaming-asynchronous-execution/README.md
@@ -206,8 +206,6 @@ For a _proposed_ block which includes timestamp $t_b$, all ancestors whose execu
 
 The _proposed_ block must include the `stateRoot` produced by the execution of the most recently settled block.
 
-Similarly, it MUST record the transaction-receipt root for all transactions executed as part of chunks in the half-open range $t_C \in (t_{B-1} - d, t_B - d]$.
-
 For any _newly_ settled blocks, the _proposed_ block must include all execution artifacts:
 - `receiptsRoot`
 - `logsBloom`

--- a/ACPs/194-streaming-asynchronous-execution/README.md
+++ b/ACPs/194-streaming-asynchronous-execution/README.md
@@ -190,6 +190,9 @@ x &~:= x + \frac{g_C}{2} \\
 \end{align}
 $$
 
+> [!NOTE]
+> The update rule here assumes that $t_e$ is a timestamp that can track the passage of time both by gas and by wall-clock time. $\frac{g_C}{R}$ MUST NOT be simply rounded. Rather, the gas accumulation should be left as a fraction.
+
 $t_e$ is now this block's execution timestamp.
 
 ### Handling gas target changes

--- a/ACPs/194-streaming-asynchronous-execution/README.md
+++ b/ACPs/194-streaming-asynchronous-execution/README.md
@@ -407,28 +407,6 @@ Other than the _earliest_ (genesis) named block, which MUST be interpreted in th
 > The finality guarantees of Snowman consensus remove any distinction between _safe_ and _finalized_. 
 > Furthermore, the _latest_ block is not at risk of re-org, only of a negligible risk of data corruption local to the API node.
 
-### Streaming vs regular asynchronous pipelining
-
-```mermaid
-sankey-beta
-  Block 0,Q,7
-  B1,Q,10
-  B2,Q,13
-  B3,Q,15
-  B4,Q,8
-  B5,Q,21
-  B6,Q,2
-  B7,Q,0
-  Q,Chunk 0,7
-  Q,C1,10
-  Q,C2,10
-  Q,C3,10
-  Q,C4,10
-  Q,C5,10
-  Q,C6,10
-  Q,C7,9
-```
-
 ### Observations around transaction prioritisation
 
 As EOA-to-EOA transfers of value are entirely guaranteed upon _acceptance_, block builders MAY choose to prioritise other transactions for earlier execution.

--- a/ACPs/194-streaming-asynchronous-execution/README.md
+++ b/ACPs/194-streaming-asynchronous-execution/README.md
@@ -179,7 +179,7 @@ x &~:= \max\left(x - T \cdot \Delta{t}, 0\right) \\
 \end{align}
 $$
 
-The block is then executed with this gas price.
+The block is then executed with the gas price calculated by the current value of $x$.
 
 After executing a block which was charged $g_C$ gas, the executor's timestamp and excess is updated:
 

--- a/ACPs/194-streaming-asynchronous-execution/README.md
+++ b/ACPs/194-streaming-asynchronous-execution/README.md
@@ -232,7 +232,7 @@ The worst-case bound on $x$ can be calculated by following the block executor up
 
 The worst-case bound on account balances can be calculated by charging the worst-case gas cost to the sender of a transaction along with deducting the value of the transaction from the sender's account balance.
 
-The `baseFeePerGas` field must be populated to the gas price based on the worst-case bound on $x$ at the start of block execution.
+The `baseFeePerGas` field MUST be populated with the gas price based on the worst-case bound on $x$ at the start of block execution.
 
 ### Configuration Parameters
 

--- a/ACPs/194-streaming-asynchronous-execution/README.md
+++ b/ACPs/194-streaming-asynchronous-execution/README.md
@@ -299,7 +299,7 @@ Transaction _acceptance_ under worst-case cost validity is therefore a guarantee
 
 Worst-case cost validity only protects against DoS at the point of execution but leaves the queue vulnerable to high-limit, low-usage transactions.
 
-For example, a malicious user could send a transfer-only transaction (21k gas) with a limit set consume the block's full gas limit.
+For example, a malicious user could send a transfer-only transaction (21k gas) with a limit set to consume the block's full gas limit.
 
 Although they would have to have sufficient funds to theoretically pay for all the reserved gas, they would never actually be charged this amount. Pushing a sufficient number of such transactions to the queue would artificially inflate the worst-case cost of other users.
 

--- a/ACPs/194-streaming-asynchronous-execution/README.md
+++ b/ACPs/194-streaming-asynchronous-execution/README.md
@@ -74,7 +74,7 @@ Prior to adding a proposed block to consensus, all validators MUST verify that t
 
 #### Accepting blocks
 
-Once a block is marked as accepted by consensus, the block is enqueued in a FIFO execution queue at the timestamp specified in the block header.
+Once a block is marked as accepted by consensus, the block is enqueued in a FIFO execution queue.
 
 #### Executing blocks
 

--- a/ACPs/194-streaming-asynchronous-execution/README.md
+++ b/ACPs/194-streaming-asynchronous-execution/README.md
@@ -170,7 +170,7 @@ Any block that could cause the total sum of gas limits for transactions in the e
 
 During the activation of SAE, the block executor's timestamp, $t_e$, is initialised to the timestamp of the last accepted block.
 
-Prior to executing a block which includes timestamp $t_b$, the executor's timestamp and excess is updated:
+Prior to executing a block with timestamp $t_b$, the executor's timestamp and excess is updated:
 
 $$
 \begin{align}


### PR DESCRIPTION
I did a pretty large pass of the ACP to:
- Convert the language to be block based
- Separate the "Specification" section into a "Description" and a "Specification" section
- Moved some of the things (like max queue size and minimum gas charged based on gas limit) out of the security considerations section and into the specification section.
- Added a Configuration Parameters parameters (the numbers we will actually use on C-chain)
- Moved the JSON RPC methods section into the appendix